### PR TITLE
remove multiple cases per arm from unions

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -122,7 +122,6 @@ class UnionTests(unittest.TestCase):
 union foo switch(int type) {
     case 1: int a;
     case 2:
-    case 3:
         float b;
     default:
         opaque c<>;
@@ -134,8 +133,8 @@ union foo switch(int type) {
                 'foo',
                 [['int'], 'type'],
                 [
-                    [[1], [['int'], 'a']],
-                    [[2, 3], [['float'], 'b']],
+                    [1, [['int'], 'a']],
+                    [2, [['float'], 'b']],
                     ['default', ['opaque', 'c', '<', '>']],
                 ]]])
 
@@ -144,9 +143,9 @@ union foo switch(int type) {
             XDRUnion(name='foo',
                 discriminant=XDRDeclaration(name='type', kind='basic', type='int', length=None),
                 members=[
-                    XDRUnionMember(cases=[1], declaration=XDRDeclaration(name='a', kind='basic', type='int', length=None)),
-                    XDRUnionMember(cases=[2, 3], declaration=XDRDeclaration(name='b', kind='basic', type='float', length=None)),
-                    XDRUnionMember(cases='default', declaration=XDRDeclaration(name='c', kind='list', type='opaque', length=None)),
+                    XDRUnionMember(case=1, declaration=XDRDeclaration(name='a', kind='basic', type='int', length=None)),
+                    XDRUnionMember(case=2, declaration=XDRDeclaration(name='b', kind='basic', type='float', length=None)),
+                    XDRUnionMember(case='default', declaration=XDRDeclaration(name='c', kind='list', type='opaque', length=None)),
                 ])])
 
 class ConstantTests(unittest.TestCase):

--- a/xdr/backends/lua/templates/union.lua
+++ b/xdr/backends/lua/templates/union.lua
@@ -2,7 +2,7 @@
 function public.read_${union.name}(reader)
     local discriminant = reader.int()
 :: for m in union.members:
-    if discriminant == ${literal(m.cases[0], constants)} then
+    if discriminant == ${literal(m.case, constants)} then
         return public.read_${union.name}_${m.declaration.name}(reader)
     end
 :: #endfor
@@ -11,7 +11,7 @@ end
 function public.write_${union.name}(writer, obj)
     local discriminant = obj.${union.discriminant.name}
 :: for m in union.members:
-    if discriminant == ${literal(m.cases[0], constants)} then
+    if discriminant == ${literal(m.case, constants)} then
         return public.write_${union.name}_${m.declaration.name}(writer, obj)
     end
 :: #endfor
@@ -19,7 +19,7 @@ end
 
 :: for m in union.members:
 function public.read_${union.name}_${m.declaration.name}(reader)
-    local obj = { ${union.discriminant.name}=${literal(m.cases[0], constants)} }
+    local obj = { ${union.discriminant.name}=${literal(m.case, constants)} }
 :: include("_unpack.lua", m=m.declaration, dst="obj.value")
     return obj
 end

--- a/xdr/backends/python/templates/union.py
+++ b/xdr/backends/python/templates/union.py
@@ -4,7 +4,7 @@ class ${union.name}(XDRUnion):
     def unpack_from(cls, unpacker):
         discriminant = unpacker.unpack_int()
 :: for m in union.members:
-        if discriminant == ${literal(m.cases[0], constants)}:
+        if discriminant == ${literal(m.case, constants)}:
             return cls.${m.declaration.name}.unpack_from(unpacker)
 :: #endfor
 :: for m in union.members:
@@ -12,7 +12,7 @@ class ${union.name}(XDRUnion):
     class ${m.declaration.name}(XDRUnionMember):
         @classmethod
         def pack_into(cls, packer, obj):
-            packer.pack_int(${literal(m.cases[0], constants)})
+            packer.pack_int(${literal(m.case, constants)})
 :: include_indented("_pack.py", indent=12, m=m.declaration, src="obj.value")
 
         @classmethod

--- a/xdr/ir.py
+++ b/xdr/ir.py
@@ -13,7 +13,7 @@ XDREnumMember = namedtuple("XDREnumMember", ["name", "value"])
 XDRConst = namedtuple("XDRConst", ["name", "value"])
 XDRTypedef = namedtuple("XDRTypedef", ["declaration"])
 XDRUnion = namedtuple("XDRUnion", ["name", "discriminant", "members"])
-XDRUnionMember = namedtuple("XDRUnionMember", ["cases", "declaration"])
+XDRUnionMember = namedtuple("XDRUnionMember", ["case", "declaration"])
 
 __all__ = [
     'XDRStruct', 'XDRDeclaration', 'XDREnum', 'XDREnumMember',

--- a/xdr/parser.py
+++ b/xdr/parser.py
@@ -48,7 +48,7 @@ enum_body = s("{") + g(P.delimitedList(g(identifier + s('=') + constant))) + s("
 
 struct_body = s("{") + P.OneOrMore(g(declaration + s(";"))) + s("}")
 
-case_spec = g(g(P.OneOrMore(s(kw("case")) - value + s(":"))) + g(declaration) + s(";"))
+case_spec = g(s(kw("case")) - value + s(":") + g(declaration) + s(";"))
 default_spec = g(kw('default') - s(':') + g(declaration) + s(';'))
 
 union_body = \


### PR DESCRIPTION
Reviewer: @sovietaced

I misread the RFC and thought it allowed multiple cases per union member, like 
C's switch statement. The backends never actually supported this.
